### PR TITLE
chore: drop support for Node.js 0.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 sudo: false
 language: node_js
 node_js:
-  - 'iojs'
   - 5
   - 4
-  - '0.12'
-  - '0.10'


### PR DESCRIPTION
BREAKING CHANGE: This module no longer supports Node.js 0.10